### PR TITLE
✨ [FEAT] 신상품 추가 서비스 구현

### DIFF
--- a/cs25server/src/main/kotlin/edu/dongguk/cs25server/domain/ItemCS.kt
+++ b/cs25server/src/main/kotlin/edu/dongguk/cs25server/domain/ItemCS.kt
@@ -13,8 +13,12 @@ import org.hibernate.annotations.DynamicUpdate
 @Table(name = "item_CS")
 class ItemCS(
         var name: String,
+
         var price: Int = 0,
+
         var stock: Int = 0,
+
+        var isNewItem: Boolean = true,
 
         @Enumerated(EnumType.STRING)
         var category: ItemCategory,
@@ -27,7 +31,7 @@ class ItemCS(
         @JoinColumn(name = "store_id")
         var store: Store? = null,
 
-        @OneToOne(fetch = FetchType.LAZY)
+        @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(name = "image_id")
         var image: Image
 ) {

--- a/cs25server/src/main/kotlin/edu/dongguk/cs25server/domain/ItemHQ.kt
+++ b/cs25server/src/main/kotlin/edu/dongguk/cs25server/domain/ItemHQ.kt
@@ -124,7 +124,7 @@ class ItemHQ(
         stock_date = this.getWarehousingDate(),
         stock_quantity = this.stock,
         supplier = this.supplier.toString(),
-        item_image_uuid = this.image.getUuidName()
+        item_image_uuid = this.image.getAccessUrl()
     )
 
     fun toOrderResponse(): OrderResponseDto {


### PR DESCRIPTION
신상품인것을 추가하기 위해 ItemCS에서 is_new_item 컬럼을 추가하였습니다. boolean 값으로 상품 추가시 true값으로 모든 점포별로 신상품에 대한 ItemCS 데이터가 추가됩니다. 또한 이미지 저장도 로컬 저장이 아닌 s3저장으로 로직을 변경하였습니다.

- ItemCS is_new_item 컬럼 추가
- 본사 상품 추가 API 호출 시, 점포별로 신상품 ItemCS 데이터 추가
- 이미지 저장 로컬 -> s3저장으로 변경