### PR TITLE
[FIX] 점주 - 소비자 주문내역 조회 타입 수정

### DIFF
--- a/cs25server/src/main/kotlin/edu/dongguk/cs25server/dto/response/CustomerOrderResponseDto.kt
+++ b/cs25server/src/main/kotlin/edu/dongguk/cs25server/dto/response/CustomerOrderResponseDto.kt
@@ -10,5 +10,5 @@ class CustomerOrderResponseDto (
         val item_cu_fielditem_name: MutableList<String>?, // item_CS
         val payment_total_price: Int?,   // Order
         val order_created_at: LocalDateTime?,    // Order
-        val order_is_picked_up: String?     // Order
+        val order_state: String?     // Order
 )


### PR DESCRIPTION
점주가 해당 점포의 소비자 주문 내역 조회시에 반환값으로 해당 주문의 상태를 반환할때 Boolean에서 String으로 변경하여 반환합니다.
EX. 픽업완료